### PR TITLE
Add favorite labs feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
         "icon": "$(copy)"
       },
       {
+        "command": "containerlab.lab.toggleFavorite",
+        "title": "Toggle Favorite",
+        "icon": "$(star)"
+      },
+      {
         "command": "containerlab.lab.deploy",
         "title": "Deploy",
         "icon": "$(play)",
@@ -531,6 +536,11 @@
           "command": "containerlab.lab.openFolderInNewWindow",
           "when": "viewItem =~ /containerlabLab/",
           "group": "labFile@4"
+        },
+        {
+          "command": "containerlab.lab.toggleFavorite",
+          "when": "view == localLabs && viewItem =~ /containerlabLab/",
+          "group": "navigation@0"
         },
         {
           "command": "containerlab.lab.deploy",

--- a/src/commands/favorite.ts
+++ b/src/commands/favorite.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+import { ClabLabTreeNode } from '../treeView/common';
+import { favoriteLabs, extensionContext } from '../extension';
+
+export async function toggleFavorite(node: ClabLabTreeNode) {
+    if (!node?.labPath?.absolute) {
+        return;
+    }
+    const absPath = node.labPath.absolute;
+    if (favoriteLabs.has(absPath)) {
+        favoriteLabs.delete(absPath);
+        await extensionContext.globalState.update('favoriteLabs', Array.from(favoriteLabs));
+        vscode.window.showInformationMessage('Removed favorite lab');
+    } else {
+        favoriteLabs.add(absPath);
+        await extensionContext.globalState.update('favoriteLabs', Array.from(favoriteLabs));
+        vscode.window.showInformationMessage('Marked lab as favorite');
+    }
+    vscode.commands.executeCommand('containerlab.refresh');
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,3 +20,4 @@ export * from "./impairments";
 export * from "./edgeshark";
 export * from "./openBrowser";
 export * from "./telnet";
+export * from "./favorite";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,10 @@ export let localTreeView: any;
 export let runningTreeView: any;
 export let username: string;
 export let hideNonOwnedLabsState: boolean = false;
+export let favoriteLabs: Set<string> = new Set();
+export let extensionContext: vscode.ExtensionContext;
+export let localLabsProvider: LocalLabTreeDataProvider;
+export let runningLabsProvider: RunningLabTreeDataProvider;
 
 export const execCmdMapping = require('../resources/exec_cmd.json');
 export const sshUserMapping = require('../resources/ssh_users.json');
@@ -67,8 +71,11 @@ export async function activate(context: vscode.ExtensionContext) {
   ins.update();
 
   // Tree data provider
-  const localLabsProvider = new LocalLabTreeDataProvider();
-  const runningLabsProvider = new RunningLabTreeDataProvider(context);
+  extensionContext = context;
+  favoriteLabs = new Set(context.globalState.get<string[]>('favoriteLabs', []));
+
+  localLabsProvider = new LocalLabTreeDataProvider();
+  runningLabsProvider = new RunningLabTreeDataProvider(context);
 
 
   localTreeView = vscode.window.createTreeView('localLabs', {
@@ -115,6 +122,9 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(
     vscode.commands.registerCommand('containerlab.lab.copyPath', cmd.copyLabPath)
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('containerlab.lab.toggleFavorite', cmd.toggleFavorite)
   );
 
   context.subscriptions.push(

--- a/src/treeView/common.ts
+++ b/src/treeView/common.ts
@@ -31,6 +31,7 @@ export class ClabLabTreeNode extends vscode.TreeItem {
     public readonly name?: string;
     public readonly owner?: string;
     public readonly containers?: ClabContainerTreeNode[];
+    public readonly favorite: boolean;
 
     constructor(
         public readonly label: string,
@@ -40,6 +41,7 @@ export class ClabLabTreeNode extends vscode.TreeItem {
         owner?: string,
         containers?: ClabContainerTreeNode[],
         contextValue?: string,
+        favorite: boolean = false,
     ) {
         super(label, collapsibleState);
         this.labPath = labPath;
@@ -47,7 +49,10 @@ export class ClabLabTreeNode extends vscode.TreeItem {
         this.owner = owner;
         this.containers = containers;
         this.contextValue = contextValue;
-        this.iconPath = vscode.ThemeIcon.File;
+        this.favorite = favorite;
+        this.iconPath = favorite
+            ? new vscode.ThemeIcon('star-full', new vscode.ThemeColor('charts.yellow'))
+            : vscode.ThemeIcon.File;
     }
 }
 

--- a/src/treeView/localLabsProvider.ts
+++ b/src/treeView/localLabsProvider.ts
@@ -2,7 +2,8 @@ import * as vscode from "vscode"
 import * as utils from "../utils"
 import * as c from "./common";
 import * as ins from "./inspector";
-import { localTreeView } from "../extension";
+import { localTreeView, favoriteLabs, extensionContext } from "../extension";
+import * as fs from "fs";
 import path = require("path");
 
 const WATCHER_GLOB_PATTERN = "**/*.clab.{yaml,yml}";
@@ -63,48 +64,61 @@ export class LocalLabTreeDataProvider implements vscode.TreeDataProvider<c.ClabL
 
         const uris = await vscode.workspace.findFiles(CLAB_GLOB_PATTERN, IGNORE_GLOB_PATTERN);
 
-        const length = uris.length;
-
-        console.log(`[LocalTreeDataProvider]:\tDiscovered ${length} labs.`);
-
-        // empty tree if no files were discovered
-        if (!length) {
-            vscode.commands.executeCommand('setContext', 'localLabsEmpty', true);
-            return undefined;
-        }
-
         const labs: Record<string, c.ClabLabTreeNode> = {};
 
         // get a list of running labPaths so we can filter out any running labs.
         const labPaths = this.getLabPaths();
 
-        uris.forEach((uri) => {
-            const normPath = utils.normalizeLabPath(uri.fsPath);
-            const relPath = path.relative(vscode.workspace.workspaceFolders![0].uri.path, uri.fsPath);
+        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
 
-            if (!labs[relPath] && !(labPaths?.has(normPath))) {
+        const addLab = (filePath: string, isFavorite: boolean) => {
+            const normPath = utils.normalizeLabPath(filePath);
+            if (!labs[normPath] && !labPaths.has(normPath)) {
+                const relPath = path.relative(workspaceRoot, filePath);
                 const labNode = new c.ClabLabTreeNode(
                     relPath,
                     vscode.TreeItemCollapsibleState.None,
                     {
-                        relative: uri.fsPath,   // this path is actually absolute as well
+                        relative: filePath,
                         absolute: normPath
                     },
                     undefined,
                     undefined,
                     undefined,
-                    "containerlabLabUndeployed"
+                    "containerlabLabUndeployed",
+                    isFavorite
                 );
 
                 labNode.description = utils.getRelLabFolderPath(normPath);
+                labs[normPath] = labNode;
+            }
+        };
 
-                labs[relPath] = labNode;
+        uris.forEach(uri => addLab(uri.fsPath, favoriteLabs?.has(utils.normalizeLabPath(uri.fsPath)) ?? false));
+
+        favoriteLabs?.forEach(p => {
+            const norm = utils.normalizeLabPath(p);
+            if (uris.find(u => utils.normalizeLabPath(u.fsPath) === norm)) {
+                return;
+            }
+            if (fs.existsSync(norm)) {
+                addLab(p, true);
+            } else {
+                favoriteLabs.delete(p);
+                if (extensionContext) {
+                    extensionContext.globalState.update('favoriteLabs', Array.from(favoriteLabs));
+                }
             }
         });
 
         let result = Object.values(labs).sort(
             (a, b) => {
-                // sort based on labPath as it has to be unique
+                if (a.favorite && !b.favorite) {
+                    return -1;
+                }
+                if (!a.favorite && b.favorite) {
+                    return 1;
+                }
                 const aPath = a.labPath?.absolute ?? '';
                 const bPath = b.labPath?.absolute ?? '';
                 return aPath.localeCompare(bPath);
@@ -116,13 +130,14 @@ export class LocalLabTreeDataProvider implements vscode.TreeDataProvider<c.ClabL
             result = result.filter(lab => String(lab.label).toLowerCase().includes(filter));
         }
 
+        const isEmpty = result.length === 0;
         vscode.commands.executeCommand(
             'setContext',
             'localLabsEmpty',
-            result.length == 0
+            isEmpty
         );
 
-        return result;
+        return isEmpty ? undefined : result;
 
     }
 

--- a/test/helpers/vscode-stub.ts
+++ b/test/helpers/vscode-stub.ts
@@ -72,9 +72,22 @@ export const TreeItemCollapsibleState = {
   Expanded: 2,
 } as const;
 
-export const ThemeIcon = {
-  File: 'file',
-};
+export class ThemeColor {
+  public id: string;
+  constructor(id: string) {
+    this.id = id;
+  }
+}
+
+export class ThemeIcon {
+  static File = 'file';
+  public id: string;
+  public color?: ThemeColor;
+  constructor(id: string, color?: ThemeColor) {
+    this.id = id;
+    this.color = color;
+  }
+}
 
 export const ViewColumn = {
   One: 1,


### PR DESCRIPTION
## Summary
- allow marking labs as favorites via new toggle command
- store favorites globally and show starred lab items
- display favorite labs in undeployed labs list across workspaces
- remove nonexistent favorite labs and keep favorites on top

## Testing
- `npm run lint`
- `npm test`
